### PR TITLE
Adjust position of .chroma-hash els if needed.

### DIFF
--- a/jquery.chroma-hash.js
+++ b/jquery.chroma-hash.js
@@ -118,6 +118,13 @@
           $input.bind('keyup', trigger).bind('blur', trigger);
         });
 
+		var me = this;
+		$(function(){
+			$(document).bind('DOMSubtreeModified', function(){
+				trigger.call(me);
+			});
+		});
+
         /*
          * A JavaScript implementation of the RSA Data Security, Inc. MD5 Message
          * Digest Algorithm, as defined in RFC 1321.


### PR DESCRIPTION
Since the .chroma-hash elements are not relative to the form, I added a listener for DOM changes to reposition them if the height of the document above them changes.
